### PR TITLE
Fix Some Bugs

### DIFF
--- a/assets/css/_common/_core/base.scss
+++ b/assets/css/_common/_core/base.scss
@@ -1,5 +1,5 @@
 /** highlight.js **/
-@import url('https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.1/build/styles/github-gist.css');
+@import url('https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.18.1/build/styles/github-gist.min.css');
 
 /** Normalize.css **/
 @import url('https://necolas.github.io/normalize.css/8.0.1/normalize.css');

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,14 +12,14 @@ function switchDarkMode() {
     }
 }
 
-(function() {
+document.addEventListener('DOMContentLoaded', function() {
     var dark = document.cookie.replace(/(?:(?:^|.*;\s*)dark\s*\=\s*([^;]*).*$)|^.*$/, "$1") || '0';
     if(dark == '0'){
         document.body.classList.remove('dark-theme');
     }else if(dark == '1'){
         document.body.classList.add('dark-theme');
     }
-})()
+});
 
 // 顶部阅读进度条
 document.addEventListener('DOMContentLoaded', function () {
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function () {
     progressBar.value = window.scrollY;
 
     document.addEventListener('scroll', function () {
-          progressBar.max = document.documentElement.scrollHeight - window.innerHeight;
-          progressBar.value = window.scrollY;
+        progressBar.max = document.documentElement.scrollHeight - window.innerHeight;
+        progressBar.value = window.scrollY;
     });
 });

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar">
     {{ if (and .IsPage (not .Params.notsb)) }}
-        <progress id="content_progress" value="0"></progress>
+        <progress id="content_progress" max="0" value="0"></progress>
     {{ end }}
     <div class="container">
         <div class="navbar-header header-logo">

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -4,7 +4,7 @@
 
 
 {{ $main := slice  $highlight $main $custom | resources.Concat "/js/vendor_main.js" | resources.Minify}}
-<script src="{{ printf "%s" $main.RelPermalink }}" async=""></script>
+<script src="{{ printf "%s" $main.RelPermalink }}" defer ></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pangu/4.0.7/pangu.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pangu@4.0.7/dist/browser/pangu.min.js"></script>
 <script> pangu.spacingPage();</script>


### PR DESCRIPTION
- **无法加载代码高亮的 CSS 文件 (404) #7**
  文件名写错了，应该是 `github-gist.min.css`

- **顶部阅读进度条经常无法使用 #8**
  JavaScript 跑得太快了，DOM 还没加载好就跑完了
  改变 `<Script>` 的加载方式，由 `async` 改为 `defer`