### PR TITLE
Redesign part of the theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Because the author of [LeaveIt](https://raw.githubusercontent.com/liuzc/LeaveIt/
 At this stage, I mainly integrate the part I modified with LeaveIt, and will add more features in the future.
 
 ## Features
-- Automatically highlighting code (Support by [highlight.js] (https://highlightjs.org/))
+- Automatically highlighting code (Support by [highlight.js](https://highlightjs.org/))
 - Dark/Light Mode
 - Support for embedded BiliBili video
 - Support hidden text

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ preserveTaxonomyNames = true
 [menu]
   [[menu.main]]
     name = "Blog"
-    url = "/posts/"
+    url = "/post/"
     weight = 1
 
   [[menu.main]]

--- a/assets/css/_common/_core/base.scss
+++ b/assets/css/_common/_core/base.scss
@@ -4,8 +4,8 @@
 /** Font **/
 /* iconfont */
 @import url('https://at.alicdn.com/t/font_1230224_omviwgy4rx.css');
-/* josefin-sans-regular && pt-sans-regular */
-@import url('https://fonts.proxy.ustclug.org/css?family=Josefin+Sans|PT+Sans&display=swap');
+/* josefin-sans-regular && Lobster && pt-sans-regular */
+@import url('https://fonts.googleapis.com/css2?family=Josefin+Sans&family=Lobster&family=PT+Sans&display=swap');
 /* Fira Code */
 @import url('https://cdn.jsdelivr.net/gh/tonsky/FiraCode@2/distr/fira_code.css');
 

--- a/assets/css/_common/_core/layout.scss
+++ b/assets/css/_common/_core/layout.scss
@@ -54,16 +54,21 @@
 
     .header-logo {
       font-weight: bold;
-      font-family: monospace, monospace;
+      font-size: 1.3em;
+      font-family: 'Lobster', cursive;
+    }
+
+    .header-back-logo {
+      font-weight: bold;
+      font-family: 'Fira Code', Consolas, Monaco, Menlo, Consolas, monospace;
     }
 
     .logo_cursor {
       display: inline-block;
       width: 10px;
-      height: 1rem;
+      height: 0.3rem;
       background: #fe5186;
-      margin-left: 5px;
-      border-radius: 1px;
+      margin-left: -8px;
       animation: cursor 1s infinite;
     }
     @media (prefers-reduced-motion: reduce) {

--- a/assets/css/_common/_core/layout.scss
+++ b/assets/css/_common/_core/layout.scss
@@ -61,19 +61,23 @@
     .header-back2home-logo {
       font-weight: bold;
       font-family: 'Fira Code', Consolas, Monaco, Menlo, Consolas, monospace;
-    }
 
-    .logo_cursor {
-      display: inline-block;
-      width: 10px;
-      height: 0.3rem;
-      background: #fe5186;
-      margin-left: -8px;
-      animation: cursor 1s infinite;
-    }
-    @media (prefers-reduced-motion: reduce) {
+      .logo_mark {
+        color: #23d18b;
+      }
+
       .logo_cursor {
-        animation: none;
+        display: inline-block;
+        width: 10px;
+        height: 0.3rem;
+        background: #fe5186;
+        margin-left: -8px;
+        animation: cursor 1s infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .logo_cursor {
+          animation: none;
+        }
       }
     }
   }

--- a/assets/css/_common/_core/layout.scss
+++ b/assets/css/_common/_core/layout.scss
@@ -48,7 +48,7 @@
     justify-content: space-between;
     font-size: 1.125em;
 
-    .theme-switch {
+    .divide {
       border-left: 2px solid;
     }
 
@@ -58,7 +58,7 @@
       font-family: 'Lobster', cursive;
     }
 
-    .header-back-logo {
+    .header-back2home-logo {
       font-weight: bold;
       font-family: 'Fira Code', Consolas, Monaco, Menlo, Consolas, monospace;
     }

--- a/assets/css/_common/_core/media.scss
+++ b/assets/css/_common/_core/media.scss
@@ -41,22 +41,8 @@
       background: $light-background-color;
       .header-logo {
         font-weight: bold;
-        font-family: monospace, monospace;
-      }
-
-      .logo_cursor {
-        display: inline-block;
-        width: 10px;
-        height: 1rem;
-        background: #fe5186;
-        margin-left: 5px;
-        border-radius: 1px;
-        animation: cursor 1s infinite;
-      }
-      @media (prefers-reduced-motion: reduce) {
-        .logo_cursor {
-        animation: none;
-        }
+        font-size: x-large;
+        font-family: 'Lobster', cursive;
       }
       .navbar-header {
         display: flex;

--- a/assets/css/_common/_core/media.scss
+++ b/assets/css/_common/_core/media.scss
@@ -44,7 +44,7 @@
         font-size: x-large;
         font-family: 'Lobster', cursive;
       }
-      .navbar-header {
+      .navbar {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -52,6 +52,8 @@
         padding-right: 1em;
         padding-left: 1em;
         box-sizing: border-box;
+        position: fixed;
+        z-index: 10;
 
         .navbar-right {
           display: flex;
@@ -121,20 +123,36 @@
       .menu {
         text-align: center;
         background: #ffffff;
-        border-top: 2px solid #000000;
-        padding-top: 1em;
-        padding-bottom: 1em;
+        width: 100%;
+        height: 100vh;
+        top: 0;
+        left: 0;
+        z-index: 9;
+        position: fixed;
         display: none;
-        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1), 0px 4px 8px rgba(0, 0, 0, 0.1);
-        a {
-          display: block;
-          line-height: 2.5em;
+        .mb-md {
+          padding-top: 150px;
+          padding-right: 15px;
+          padding-left: 15px;
+          margin-right: auto;
+          margin-left: auto;
+          a {
+            display: block;
+            line-height: 2.5em;
+            font-size: 2em;
+            margin: auto;
+            width: min-content;
+            &.active .menu-active {
+                position: relative;
+                top: -10vw;
+                height: 4px;
+                background-color: #dd1912;
+            }
+          }
         }
-
         &.active {
           display: block;
         }
-
         .dark-theme & {
           background: $dark-background-color;
           border-top: 2px solid $dark-font-secondary-color;
@@ -232,7 +250,7 @@
 
     background: $dark-background-color !important;
 
-    .navbar-header .menu-toggle span {
+    .navbar .menu-toggle span {
       background: $dark-font-color;
     }
 

--- a/assets/css/_common/_partials/navbar.scss
+++ b/assets/css/_common/_partials/navbar.scss
@@ -25,6 +25,9 @@
   }
   
   .navbar-header a:hover, .navbar .navbar-right a:hover {
-    
     background-color: transparent;
+  }
+
+  .navbar-header a:hover {
+    color: #fe5186;
   }

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,7 +22,7 @@ preserveTaxonomyNames = true
 [menu]
   [[menu.main]]
     name = "Blog"
-    url = "/posts/"
+    url = "/post/"
     weight = 1
 
   [[menu.main]]

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,17 +3,20 @@
         <progress class="content_progress" max="0" value="0"></progress>
     {{ end }}
     <div class="container">
+        {{ if .IsHome }}
         <div class="navbar-header header-logo">
-            {{ if .IsHome }}
-        	<a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-            {{ else }}
-            <span class="logo_mark" >></span>
+            <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+        </a>
+        </div>
+        {{ else }}
+        <div class="navbar-header header-back-logo">
+            <span class="logo_mark" >>$</span>
             <a href="{{ .Site.BaseURL }}">
-                <span class="logo_text" >$ cd /home/ </span>
+                <span class="logo_text" >cd /home/</span>
                 <span class="logo_cursor" ></span>
             </a>
-            {{ end }}
         </div>
+        {{ end }}
         <div class="navbar-right">
                 {{ $currentPage := . }}
                 <span class="menu">
@@ -33,15 +36,7 @@
      <div class="container">
         <div class="navbar-header">
             <div class="header-logo">
-                {{ if .IsHome }}
                     <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-                {{ else }}
-                    <span class="logo_mark">></span>
-                    <a href="{{ .Site.BaseURL }}">
-                        <span class="logo_text">$ cd /home/ </span>
-                        <span class="logo_cursor"></span>
-                </a>
-                {{ end }}
             </div>
             <div class="navbar-right">
                 <a href="javascript:void(0);" class="theme-switch"><i class="iconfont icon-dark-mode"></i></a>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,20 +1,20 @@
 <nav class="navbar">
-    {{ if (and .IsPage (not .Params.notsb)) }}
+    {{ if (and .IsPage (.Site.Params.contentProgress | default true)) }}
         <progress class="content_progress" max="0" value="0"></progress>
     {{ end }}
     <div class="container">
-        {{ if .IsHome }}
-        <div class="navbar-header header-logo">
-            <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-        </a>
-        </div>
-        {{ else }}
-        <div class="navbar-header header-back-logo">
+        {{ if (and (not .IsHome) (.Site.Params.Back2Home | default true)) }}
+        <div class="navbar-header header-back2home-logo">
             <span class="logo_mark" >>$</span>
             <a href="{{ .Site.BaseURL }}">
                 <span class="logo_text" >cd /home/</span>
                 <span class="logo_cursor" ></span>
             </a>
+        </div>
+        {{ else }}
+        <div class="navbar-header header-logo">
+            <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+        </a>
         </div>
         {{ end }}
         <div class="navbar-right">
@@ -30,7 +30,7 @@
     </div>
 </nav>
 <nav class="navbar-mobile" id="nav-mobile" style="display: none">
-    {{ if (and .IsPage (not .Params.notsb)) }}
+    {{ if (and .IsPage (.Site.Params.contentProgress | default true)) }}
         <progress class="content_progress" max="0" value="0"></progress>
     {{ end }}
      <div class="container">
@@ -39,7 +39,7 @@
                     <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
             </div>
             <div class="navbar-right">
-                <a href="javascript:void(0);" class="theme-switch"><i class="iconfont icon-dark-mode"></i></a>
+                <div><a href="javascript:void(0);" class="theme-switch"><i class="iconfont icon-dark-mode"></i></a></div>
                 <div class="menu-toggle">
                     <span></span><span></span><span></span>
                 </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,18 +4,17 @@
     {{ end }}
     <div class="container">
         {{ if (and (not .IsHome) (.Site.Params.Back2Home | default true)) }}
-        <div class="navbar-header header-back2home-logo">
-            <span class="logo_mark" >>$</span>
-            <a href="{{ .Site.BaseURL }}">
-                <span class="logo_text" >cd /home/</span>
-                <span class="logo_cursor" ></span>
-            </a>
-        </div>
+            <div class="navbar-header header-back2home-logo">
+                <span class="logo_mark" >>$</span>
+                <a href="{{ .Site.BaseURL }}">
+                    <span class="logo_text" >cd /home/</span>
+                    <span class="logo_cursor" ></span>
+                </a>
+            </div>
         {{ else }}
-        <div class="navbar-header header-logo">
-            <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
-        </a>
-        </div>
+            <div class="navbar-header header-logo">
+                <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+            </div>
         {{ end }}
         <div class="navbar-right">
                 {{ $currentPage := . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -33,8 +33,8 @@
         <progress class="content_progress" max="0" value="0"></progress>
     {{ end }}
      <div class="container">
-        <div class="navbar-header">
-            <div class="header-logo">
+        <div class="navbar">
+            <div class="navbar-header header-logo">
                     <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
             </div>
             <div class="navbar-right">
@@ -46,10 +46,15 @@
         </div>
      
           <div class="menu" id="mobile-menu">
-                {{ $currentPage := . }}
-                {{ range .Site.Menus.main }}
-                <a class="menu-item{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a>
-                {{ end }}
+                <nav class="mb-md">
+                    {{ $currentPage := . }}
+                    {{ range .Site.Menus.main }}
+                        <a class="menu-item{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} active{{end}}" href="{{ .URL }}" title="{{ .Title }}">
+                            <h3>{{ .Name }}</h3>
+                            <div class="menu-active"></div>
+                        </a>
+                    {{ end }}
+                </nav>
         </div>
     </div>
 </nav>


### PR DESCRIPTION
重新设计了一些样式

- Logo
- 移动端菜单

## Logo

Logo 部分将 `Normal` 样式的字体变为了 [Lobster](https://fonts.google.com/specimen/Lobster?query=Lobster&preview.text=Mogeko%60s+Blog&preview.text_type=custom)，将 `Back2Home` 样式的字体变为 Fira Code。 https://github.com/Mogeko/mogege/commit/ce52636c39be7f80ad2d6e4c4ae7a2b73c89f303

砍掉了移动端的 `Back2Home` 样式

修改了鼠标悬停在 Logo 上时的样式 https://github.com/Mogeko/mogege/commit/36285f57e7efacd33f0a78ce0c7151aa82a42807

在 `config.toml` 中加入新的设置项控制是否开启 `Back2Home` 样式 https://github.com/Mogeko/mogege/commit/4520e1741f5c88e438cfea7dac097c7df63cb4ee

```
[Params]
    Back2Home = false # 默认为 true
```

更多细节：
- PC 端:
  - Normal: Lobster, 1.3em
  - Back2Home: Fira Code, 1.125em
- 移动端:
  - Normal: Lobster, x-large

Normal
![Snipaste_2020-04-06_21-54-19](https://user-images.githubusercontent.com/26341224/78605327-99728e00-785b-11ea-8bdd-f81d6293bbbf.jpg)

Normal (`:hover`):
![Snipaste_2020-04-07_00-38-54](https://user-images.githubusercontent.com/26341224/78614392-ba90aa00-786e-11ea-99ab-f82bbf4e7866.jpg)

Back2Home:
![Snipaste_2020-04-07_00-42-27](https://user-images.githubusercontent.com/26341224/78612161-f7f23900-7868-11ea-9d74-f96fd2709c21.jpg)

Back2Home (`:hover`):
![Snipaste_2020-04-07_00-44-06](https://user-images.githubusercontent.com/26341224/78614443-e0b64a00-786e-11ea-85a0-e63e46d7d28a.jpg)

## 移动端菜单

重新设计移动端菜单 https://github.com/Mogeko/mogege/commit/00e2ce8313c0fb0271ace247da6ceadd2febea0c

新的移动端菜单将全屏显示菜单内容

![Screenshot_0](https://user-images.githubusercontent.com/26341224/78662291-6d452480-78d0-11ea-95d7-93091a9ef21d.png)

使用红色的「删除线」指示你的位置 (在文章页面中无效)

![Screenshot_1](https://user-images.githubusercontent.com/26341224/78662407-9b2a6900-78d0-11ea-957e-744189027583.png)


issue #15 