### PR TITLE
Update(feature): Bilibili Shortcodes supports BV and PV

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ Make sure your browser version:
 
 ## Embedded BiliBili video
 
-You can embed BiliBili videos via Shortcodes, just provide the AV 号 of the
+You can embed BiliBili videos via Shortcodes, just provide the AV号/BV号 of the
 bilibili video
 
+You can also use the PV号 to control the 分P (default: `1`)
+
 ```txt
-{{< bilibili [AV号] >}}
+{{< bilibili [AV号/BV号] [PV号] >}}
 ```
 
 Click [here](https://mogeko.github.io/2020/079#biliplayer) for examples

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Make sure your browser version:
 
 ## Embedded BiliBili video
 
-You can embed BiliBili videos via Shortcodes, just provide the AV号/BV号 of the
-bilibili video
+You can embed BiliBili videos via Shortcodes, just provide the AV 号/BV 号 of
+the bilibili video
 
-You can also use the PV号 to control the 分P (default: `1`)
+You can also use the PV 号 to control the 分 P (default: `1`)
 
 ```txt
 {{< bilibili [AV号/BV号] [PV号] >}}

--- a/layouts/shortcodes/bilibili.html
+++ b/layouts/shortcodes/bilibili.html
@@ -1,1 +1,8 @@
-<div><iframe id="biliplayer" src="//player.bilibili.com/player.html?aid={{ index .Params 0 }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" loading="lazy" > </iframe></div>
+{{ $videoID := index .Params 0 }}
+{{ $pageNum := index .Params 1 | default 1}}
+
+{{ if (findRE "^[bB][vV][0-9a-zA-Z]+$" $videoID) }}
+<div><iframe id="biliplayer" src="//player.bilibili.com/player.html?bvid={{ $videoID }}&page={{ $pageNum }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" loading="lazy" > </iframe></div>
+{{ else }}
+<div><iframe id="biliplayer" src="//player.bilibili.com/player.html?aid={{ $videoID }}&page={{ $pageNum }}" scrolling="no" border="0" frameborder="no" framespacing="0" allowfullscreen="true" loading="lazy" > </iframe></div>
+{{ end }}


### PR DESCRIPTION
现在可以在 Bilibili Shortcodes 中使用 `BV号` 和 PV号(分P) 了

会自动判断你使用的是 `AV号` 还是 `BV号`，`AV号` **不需要**以 `av/AV` 开头，`BV号` **必须**以 `bv/BV` 开头
`PV号` 写在 `AV/BV号` 后面，**仅数字，不需要**以 `pv/PV` 开头 (`1` 表示 `pv1`，`2` 表示 `pv2`，默认为 `1`)
```
{{< bilibili [AV号/BV号] [PV号] >}}
```

[more details](https://mogeko.me/2020/079/#%E7%94%A8%E6%B3%95)

issue #27