### PR TITLE
Fix(bug): Fix bug that can't close comment area

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -95,7 +95,7 @@
     </div>
 
     <div class="post-comment">
-        {{ if ( .Site.Params.showComments | default true ) }}
+        {{ if ( $.Params.showComments | default true ) }}
             {{ if ne .Site.DisqusShortname "" }}
                 {{ template "_internal/disqus.html" . }}
             {{ else if .Site.Params.enableGitalk }}


### PR DESCRIPTION
修复无法使用 `showComments: false` 关闭评论区的 bug
issue #30